### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ cd ~/turtlebot3_ws/src
 git clone https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git && cd turtlebot3_msgs/ && git checkout foxy-devel && cd ~/turtlebot3_ws/src
 git clone https://github.com/ROBOTIS-GIT/turtlebot3.git && cd turtlebot3 && git checkout foxy-devel && cd ~/turtlebot3_ws/src
 git clone https://github.com/TIERS/turtlebot3_simulations/ && cd turtlebot3_simulations && git checkout foxy-devel
+source /opt/ros/foxy/setup.bash
 cd ~/turtlebot3_ws && colcon build
 ```
 


### PR DESCRIPTION
According to issue: https://github.com/ros2/ros2/issues/710, if the source step is missing, none of the ROS 2 packages can be found.